### PR TITLE
fix: correct aes_key format and media fields for image/video/file sending

### DIFF
--- a/plugins/weixin/src/media.ts
+++ b/plugins/weixin/src/media.ts
@@ -141,7 +141,7 @@ export async function uploadFile(params: {
 
   return {
     encryptQueryParam,
-    aesKey: aesKey.toString("base64"),
+    aesKey: Buffer.from(aesKey.toString("hex")).toString("base64"),
     fileSize,
     rawSize,
     fileName: basename(filePath),

--- a/plugins/weixin/src/send.ts
+++ b/plugins/weixin/src/send.ts
@@ -97,6 +97,7 @@ export async function sendMediaFile(params: {
   const cdnMedia: CDNMedia = {
     encrypt_query_param: uploaded.encryptQueryParam,
     aes_key: uploaded.aesKey,
+    encrypt_type: 1,
   };
 
   // Build item list
@@ -115,19 +116,19 @@ export async function sendMediaFile(params: {
     case 1: // IMAGE
       items.push({
         type: MessageItemType.IMAGE,
-        image_item: { media: cdnMedia },
+        image_item: { media: cdnMedia, mid_size: uploaded.fileSize },
       });
       break;
     case 2: // VIDEO
       items.push({
         type: MessageItemType.VIDEO,
-        video_item: { media: cdnMedia, video_size: uploaded.rawSize },
+        video_item: { media: cdnMedia, video_size: uploaded.fileSize },
       });
       break;
     default: // FILE
       items.push({
         type: MessageItemType.FILE,
-        file_item: { media: cdnMedia, file_name: uploaded.fileName },
+        file_item: { media: cdnMedia, file_name: uploaded.fileName, len: String(uploaded.rawSize) },
       });
       break;
   }


### PR DESCRIPTION
## Problem

Sending images/videos/files via `sendMediaFile` results in the recipient receiving a media-type message with **empty content** — the message type is correct (image/video/file), but the actual media cannot be displayed or downloaded.

## Root Cause

Three issues in the outbound media message construction:

### 1. `aes_key` encoding mismatch (primary cause)

The WeChat client expects `aes_key` in the format `base64(hex_string_32_chars)`, which it decodes as:
```
base64 decode → 32-byte ASCII hex string → hex decode → 16-byte AES key
```

The current code sends `base64(raw_16_bytes)`, which decodes to 16 bytes that don't form a valid hex string — causing the client to fail silently when decrypting the CDN-hosted media.

### 2. Missing `encrypt_type: 1` in CDNMedia

Required by the client to know the encryption scheme used. Without it the client cannot properly locate and decrypt the media payload.

### 3. Missing size metadata

- `ImageItem.mid_size` (ciphertext size) — absent
- `VideoItem.video_size` — incorrectly set to plaintext size instead of ciphertext size
- `FileItem.len` (plaintext size as string) — absent

## Fix

| File | Line | Before | After |
|------|------|--------|-------|
| `media.ts` | 144 | `aesKey.toString("base64")` | `Buffer.from(aesKey.toString("hex")).toString("base64")` |
| `send.ts` | 99 | `{ encrypt_query_param, aes_key }` | `{ encrypt_query_param, aes_key, encrypt_type: 1 }` |
| `send.ts` | 119 | `image_item: { media }` | `image_item: { media, mid_size: uploaded.fileSize }` |
| `send.ts` | 124 | `video_size: uploaded.rawSize` | `video_size: uploaded.fileSize` |
| `send.ts` | 130 | `file_item: { media, file_name }` | `file_item: { media, file_name, len: String(uploaded.rawSize) }` |

## Verification

1. Manually tested CDN upload → confirmed `encryptQueryParam` returned successfully
2. Sent image with original format → received empty image message (bug confirmed)
3. Sent image with fixed format → **image content displayed correctly** ✅

## Reference

Format aligned with the [official `@tencent-weixin/openclaw-weixin`](https://www.npmjs.com/package/@tencent-weixin/openclaw-weixin) v1.0.3 implementation (`src/messaging/send.ts` and `src/cdn/upload.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)