### PR TITLE
fix(mcp): add common bun install paths to PATH for macOS compatibility

### DIFF
--- a/plugins/weixin/.mcp.json
+++ b/plugins/weixin/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "weixin": {
-      "command": "bun",
-      "args": ["run", "--cwd", "${CLAUDE_PLUGIN_ROOT}", "--shell=bun", "--silent", "start"]
+      "command": "/bin/sh",
+      "args": ["-c", "PATH=\"$HOME/.bun/bin:$HOME/.volta/bin:$PATH\" bun run --cwd \"${CLAUDE_PLUGIN_ROOT}\" --shell=bun --silent start"]
     }
   }
 }


### PR DESCRIPTION
## Summary

- On macOS, Claude Code launches MCP servers without sourcing the user's shell profile, so `bun` installed via the official installer (`~/.bun/bin`) is not in `PATH`
- This causes `plugin:weixin:weixin` to show as **failed** in the MCP panel
- Fix wraps the command in `/bin/sh` and prepends `~/.bun/bin` and `~/.volta/bin` to PATH

## Changes

- `plugins/weixin/.mcp.json`: change `command` from `bun` to `/bin/sh -c`, prepending common bun/volta install paths

## Testing

- Verified locally on macOS: `plugin:weixin:weixin` now connects successfully after this change