### PR TITLE
feat: Add MiniMax API auto-reply for WeChat messages

### DIFF
--- a/plugins/weixin/server.ts
+++ b/plugins/weixin/server.ts
@@ -13,11 +13,65 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { existsSync } from "node:fs";
 
-import { loadAccount, DEFAULT_BASE_URL, CDN_BASE_URL } from "./src/accounts.js";
+import { loadAccount, DEFAULT_BASE_URL, CDN_BASE_URL, loadAnthropicCredentials } from "./src/accounts.js";
 import { startPollLoop, getContextToken, type ParsedMessage } from "./src/monitor.js";
 import { sendText, sendMediaFile } from "./src/send.js";
 import { getConfig, sendTyping } from "./src/api.js";
 import { TypingStatus } from "./src/types.js";
+
+/** Call MiniMax API to generate a response */
+async function generateAIResponse(userMessage: string, chatId: string): Promise<string | null> {
+  const creds = loadAnthropicCredentials();
+  if (!creds) {
+    process.stderr.write("[weixin] No Anthropic credentials found in settings.json, skipping auto-reply\n");
+    return null;
+  }
+
+  try {
+    const response = await fetch(`${creds.baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": creds.token,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: creds.model,
+        max_tokens: 1024,
+        messages: [
+          {
+            role: "user",
+            content: userMessage,
+          },
+        ],
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      process.stderr.write(`[weixin] MiniMax API error: ${response.status} ${errorText}\n`);
+      return null;
+    }
+
+    const data = await response.json();
+    // MiniMax response format: content is an array with objects having type: "text" or "thinking"
+    const content = (data as any)?.content;
+    if (Array.isArray(content)) {
+      const textItem = content.find((item: any) => item.type === "text");
+      if (textItem?.text) {
+        return textItem.text;
+      }
+      const thinkingItem = content.find((item: any) => item.type === "thinking");
+      if (thinkingItem?.thinking) {
+        return thinkingItem.thinking;
+      }
+    }
+    return "收到消息";
+  } catch (err) {
+    process.stderr.write(`[weixin] Failed to call MiniMax API: ${err}\n`);
+    return null;
+  }
+}
 
 const server = new Server(
   { name: "weixin", version: "0.2.0" },
@@ -220,6 +274,7 @@ async function main() {
     cdnBaseUrl,
     token: account.token,
     onMessage: async (msg: ParsedMessage) => {
+      // Send notification to Claude Code (for cases where Claude Code processes it)
       await server.notification({
         method: "notifications/claude/channel",
         params: {
@@ -233,6 +288,20 @@ async function main() {
           },
         },
       });
+
+      // Auto-reply via MiniMax API if ANTHROPIC_AUTH_TOKEN is set
+      const contextToken = getContextToken(msg.fromUserId) || "";
+      const aiResponse = await generateAIResponse(msg.text, msg.fromUserId);
+      if (aiResponse) {
+        await sendText({
+          to: msg.fromUserId,
+          text: aiResponse,
+          baseUrl,
+          token: account.token,
+          contextToken,
+        });
+        process.stderr.write(`[weixin] Auto-replied to ${msg.fromUserId}: ${aiResponse.substring(0, 50)}...\n`);
+      }
     },
     abortSignal: controller.signal,
   });

--- a/plugins/weixin/src/accounts.ts
+++ b/plugins/weixin/src/accounts.ts
@@ -51,3 +51,19 @@ export function clearAccount(): void {
     unlinkSync(p);
   }
 }
+
+/** Load Anthropic API credentials from ~/.claude/settings.json */
+export function loadAnthropicCredentials(): { token: string; baseUrl: string; model: string } | null {
+  const settingsPath = join(homedir(), ".claude", "settings.json");
+  if (!existsSync(settingsPath)) return null;
+  try {
+    const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    const token = settings.env?.ANTHROPIC_AUTH_TOKEN;
+    const baseUrl = settings.env?.ANTHROPIC_BASE_URL || "https://api.minimaxi.com/anthropic";
+    const model = settings.env?.ANTHROPIC_MODEL || "MiniMax-M2.7";
+    if (!token) return null;
+    return { token, baseUrl, model };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

  Add MiniMax API auto-reply support for WeChat messages. When server.ts receives a WeChat message, it now calls the configured Anthropic/MiniMax API
  directly to generate a response and sends it back to WeChat automatically.

  This enables WeChat auto-reply even when Claude Code's built-in channel notification protocol (`--dangerously-load-development-channels`) is not available
   — for example, when using MiniMax API instead of Anthropic's official API.

  ## Changes

  - **plugins/weixin/src/accounts.ts**: Add `loadAnthropicCredentials()` function that reads API credentials and configuration from
  `~/.claude/settings.json` (token, baseUrl, model)

  - **plugins/weixin/server.ts**:
    - Add `generateAIResponse()` function that calls the AI API and correctly parses MiniMax's response format (content array with objects having `type:
  "text"` or `type: "thinking"`)
    - Modify `onMessage` handler to automatically reply via the AI API when a WeChat message is received

  ## How it works

  1. WeChat message arrives at server.ts via long-polling
  2. `onMessage` callback triggers `generateAIResponse()` with the user's message
  3. `generateAIResponse()` reads credentials from settings.json and calls the AI API
  4. The response is parsed (MiniMax format → extract `text` field from content array)
  5. Reply is sent back to WeChat via `sendText()`

  ## Test

  Run `bun server.ts` and send a message from WeChat — the bot should automatically reply using the configured AI model.

  ## Notes

  - Works with both Anthropic API and MiniMax API (uses settings.json config)
  - Falls back gracefully if no credentials are found
  - MiniMax API uses a different response format than Anthropic — the `content` array contains objects with `type: "text"` or `type: "thinking"` instead of
  a simple `text` field