### PR TITLE
fix(mcp): cross-platform launcher for Windows/macOS/Linux

### DIFF
--- a/plugins/weixin/.mcp.json
+++ b/plugins/weixin/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "weixin": {
-      "command": "/bin/sh",
-      "args": ["-c", "PATH=\"$HOME/.bun/bin:$HOME/.volta/bin:$PATH\" bun run --cwd \"${CLAUDE_PLUGIN_ROOT}\" --shell=bun --silent start"]
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-launch.cjs"]
     }
   }
 }

--- a/plugins/weixin/mcp-launch.cjs
+++ b/plugins/weixin/mcp-launch.cjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform launcher for the WeChat MCP server.
+ *
+ * Why this file exists:
+ *   Claude Code spawns MCP servers with a minimal environment. The previous
+ *   `.mcp.json` used a `bash -c "..."` wrapper to prepend `~/.bun/bin` and
+ *   `~/.volta/bin` to PATH (PR #14, then extended), which fixed macOS GUI
+ *   launches where the user's shell profile is not sourced. Windows, however,
+ *   typically has no POSIX shell on PATH, so that wrapper makes the plugin
+ *   fail to start on Windows entirely.
+ *
+ *   `.mcp.json` cannot conditionally branch on OS, so we centralize the
+ *   "find bun and start the server" logic here. Node.js is used as the
+ *   launcher runtime because it is the most widely available stable runtime
+ *   on developer machines across all three OSes.
+ */
+
+"use strict";
+
+const { spawn, spawnSync } = require("node:child_process");
+const { existsSync } = require("node:fs");
+const { constants, homedir, platform } = require("node:os");
+const { join } = require("node:path");
+
+const isWindows = platform() === "win32";
+const bunExe = isWindows ? "bun.exe" : "bun";
+
+/** Locate the bun executable across PATH and common install locations. */
+function findBun() {
+  const home = homedir();
+  const candidates = [
+    join(home, ".bun", "bin", bunExe),
+    join(home, ".volta", "bin", bunExe),
+  ];
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  // Fall through to PATH lookup; spawn will report ENOENT if it is missing.
+  return bunExe;
+}
+
+const bun = findBun();
+const root = __dirname;
+
+// Step 1: install dependencies (idempotent, near-instant on no-op).
+//
+// stdout is redirected to our stderr (fd 2): MCP speaks JSON-RPC over the
+// launcher's stdout, and bun may print non-protocol lines like "Saved lockfile"
+// even with --no-summary, which would corrupt the stream.
+const install = spawnSync(bun, ["install", "--no-summary"], {
+  cwd: root,
+  stdio: ["ignore", 2, "inherit"],
+});
+if (install.error || install.status !== 0) {
+  const detail = install.error ? `: ${install.error.message}` : "";
+  process.stderr.write(
+    `[weixin] bun install failed (exit ${install.status ?? "?"})${detail}\n`,
+  );
+  process.exit(install.status ?? 1);
+}
+
+// Step 2: launch the MCP server with stdio inherited so the host can speak
+// MCP over stdin/stdout.
+const child = spawn(bun, ["server.ts"], {
+  cwd: root,
+  stdio: "inherit",
+});
+
+const forward = (sig) => {
+  if (!child.killed) child.kill(sig);
+};
+process.on("SIGINT", () => forward("SIGINT"));
+process.on("SIGTERM", () => forward("SIGTERM"));
+process.on("SIGHUP", () => forward("SIGHUP"));
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    // Don't re-raise the signal: we have SIGINT/SIGTERM/SIGHUP listeners
+    // installed, which override Node's default exit behavior and would leave
+    // the launcher hanging. Convey cause via the conventional 128+signum code.
+    const signum = constants.signals[signal] ?? 0;
+    process.exit(128 + signum);
+  }
+  process.exit(code ?? 0);
+});
+
+child.on("error", (err) => {
+  process.stderr.write(`[weixin] failed to spawn bun: ${err.message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Replace the shell wrapper in `plugins/weixin/.mcp.json` (currently `bash -c "..."`) with a Node.js launcher (`mcp-launch.cjs`) so the plugin works on Windows in addition to macOS and Linux.
- Preserves the macOS PATH fallback introduced in #14 (`~/.bun/bin`, `~/.volta/bin`) and extends it to Windows (`bun.exe` under the same dirs).

## Background

PR #14 fixed macOS GUI launches by wrapping the command in a POSIX shell that prepends bun install dirs to PATH (later evolved into the current `bash -c` form). However:

- **Windows typically has no POSIX shell on PATH**, so the plugin fails to start there. The MCP server process is never spawned and WeChat messages are never delivered to Claude Code.
- The `Listening for channel messages from: plugin:weixin@cc-weixin` banner is misleading — it only confirms channel registration, **not** that the server actually runs. So the failure is silent: no error surfaces to the user, the banner says everything is fine, and messages just disappear.
- `.mcp.json` doesn't support per-OS branching, so a single `command` must work on all three OSes.

## Changes

- **NEW** `plugins/weixin/mcp-launch.cjs` (~90 lines, CommonJS for max compat):
  - Locate `bun` via PATH first, then fall back to `~/.bun/bin/bun(.exe)` and `~/.volta/bin/bun(.exe)`.
  - Run `bun install --no-summary` with stdout redirected to stderr (fd 2) so non-protocol output like `Saved lockfile` cannot corrupt the MCP JSON-RPC stream over stdout. Surfaces `spawnSync` errors (e.g. ENOENT when bun isn't found) in the failure message.
  - Spawn `bun server.ts` with `cwd = __dirname`, inheriting stdio so the host can speak MCP over stdin/stdout.
  - Forward SIGINT / SIGTERM / SIGHUP to the child for graceful shutdown. When the child exits via signal, exit with the conventional `128 + signum` code instead of re-raising the signal (which would re-enter our own listeners and hang the launcher).
- **MODIFIED** `plugins/weixin/.mcp.json`:
  - `command`: `bash` → `node`
  - `args`: shell-script string → `["${CLAUDE_PLUGIN_ROOT}/mcp-launch.cjs"]`

## Trade-off

Introduces a Node.js dependency for the launcher itself. Bun cannot bootstrap itself when not on PATH, but Node.js is broadly preinstalled on developer machines (and trivially added if missing), so this is a pragmatic choice. Open to feedback if the maintainer prefers a pure-bun launcher (e.g. a small Rust/Go binary, or platform-specific shell scripts), but those add more friction than this single CommonJS file.

## Testing

Verified locally on **Windows 11 + PowerShell** (where the previous shell-wrapper config fails silently):

```
> node mcp-launch.cjs
[weixin] Account loaded, starting poll loop...
[weixin] Starting message poll loop...
```

(stdout stays empty — confirmed by piping `1>stdout.log 2>stderr.log` and checking `stdout.log` is zero bytes while `stderr.log` contains the lines above.)

After replacing `.mcp.json` and restarting Claude Code, WeChat messages are delivered as expected. Without this fix, the same setup on Windows shows the connection banner but never delivers any message.

macOS / Linux behavior should be unchanged — the launcher's discovery list is a superset of the previous PATH prepend, and stdout/stderr semantics are equivalent to the existing `1>&2` redirect.

## Out of scope

- No changes to `.codex-mcp.json` — Codex uses a separate `start-codex.sh` flow that already handles cross-platform concerns differently.
- No changes to skills / docs.

## Review feedback addressed

Both Copilot review comments addressed in the latest force-push:

1. **stdout pollution**: `bun install` stdout redirected to stderr (fd 2); `install.error` now included in the failure message so users see the underlying cause (e.g. `ENOENT` when bun isn't found) instead of just an exit code.
2. **Signal-handler hang**: child-exit handler no longer re-raises the signal to itself (which would re-enter our own SIGINT/SIGTERM/SIGHUP listeners and leave the launcher running). It now `process.exit(128 + signum)` directly.