### PR TITLE
fix(codex): harden Weixin MCP startup in desktop launches

### DIFF
--- a/docs/INSTALL-CODEX.md
+++ b/docs/INSTALL-CODEX.md
@@ -89,6 +89,7 @@ $weixin-configure
 ```
 
 这会同时启动 Codex App Server 和微信桥接进程，日志实时显示在终端。按 `Ctrl+C` 停止。
+脚本会自动补充 Bun 常见安装路径（`~/.bun/bin`、`~/.volta/bin`），因此不要求从登录 shell 启动。
 
 ```
 [weixin] Starting Codex App Server at ws://127.0.0.1:4500...
@@ -134,6 +135,21 @@ $weixin-access policy allowlist
 2. 从微信发消息，AI 自动处理并回复
 
 无需打开 Codex TUI（TUI 也看不到对话内容）。
+
+## 故障排查
+
+### `MCP startup failed: connection closed: initialize response`
+
+这通常表示 Codex 在启动插件 MCP 子进程时，子进程还没完成 `initialize` 就退出了。常见原因是 Codex App 的启动环境不是登录 shell，继承的 `PATH` 里没有 `bun`，或启动目录不是插件根目录。
+
+当前插件的 `.codex-mcp.json` 会显式设置插件工作目录，并在启动命令中补充 Bun 常见安装路径。如果仍然出现该错误，先确认：
+
+```bash
+bun --version
+codex mcp list
+```
+
+`codex mcp list` 中 `weixin` 应该显示为 enabled，并能看到 `CODEX_WS_URL` 环境变量。扫码登录状态不会导致 `initialize response` 握手关闭；未登录只会在工具调用或桥接运行时提示重新配置。
 
 ## 卸载
 

--- a/plugins/weixin/.codex-mcp.json
+++ b/plugins/weixin/.codex-mcp.json
@@ -3,9 +3,10 @@
     "weixin": {
       "type": "stdio",
       "command": "sh",
+      "cwd": ".",
       "args": [
         "-c",
-        "bun install --no-summary --cwd \"${CODEX_PLUGIN_ROOT:-.}\" 1>&2 && exec bun --cwd \"${CODEX_PLUGIN_ROOT:-.}\" server-codex.ts"
+        "export PATH=\"$HOME/.bun/bin:$HOME/.volta/bin:$PATH\"; PLUGIN_ROOT=\"${CODEX_PLUGIN_ROOT:-$PWD}\"; bun install --no-summary --frozen-lockfile --cwd \"$PLUGIN_ROOT\" 1>&2 && exec bun --cwd \"$PLUGIN_ROOT\" server-codex.ts"
       ],
       "env": {
         "CODEX_WS_URL": "ws://127.0.0.1:4500"

--- a/plugins/weixin/src/codex-mcp-config.test.ts
+++ b/plugins/weixin/src/codex-mcp-config.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pluginRoot = fileURLToPath(new URL("..", import.meta.url));
+const configPath = fileURLToPath(new URL("../.codex-mcp.json", import.meta.url));
+
+type CodexMcpServer = {
+  type: string;
+  command: string;
+  args: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+};
+
+function loadWeixinServer(): CodexMcpServer {
+  const config = JSON.parse(readFileSync(configPath, "utf8")) as {
+    mcpServers: { weixin: CodexMcpServer };
+  };
+  return config.mcpServers.weixin;
+}
+
+function runServerStartup(server: CodexMcpServer, options: { cwd: string; env?: Record<string, string> }) {
+  return spawnSync(server.command, server.args, {
+    cwd: options.cwd,
+    env: {
+      HOME: process.env.HOME || "",
+      PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+      ...(server.env || {}),
+      ...(options.env || {}),
+    },
+    input: "",
+    encoding: "utf8",
+    timeout: 5000,
+  });
+}
+
+describe("Codex MCP config", () => {
+  test("declares plugin root cwd for Codex plugin launches", () => {
+    const server = loadWeixinServer();
+
+    expect(server.cwd).toBe(".");
+  });
+
+  test("starts from the plugin root even when Bun is not on the inherited PATH", () => {
+    const server = loadWeixinServer();
+    const result = runServerStartup(server, { cwd: pluginRoot });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("bun: not found");
+    expect(result.stderr).not.toContain("could not find a package.json");
+  });
+
+  test("starts from another cwd when CODEX_PLUGIN_ROOT is provided", () => {
+    const server = loadWeixinServer();
+    const cwd = mkdtempSync(join(tmpdir(), "weixin-codex-mcp-cwd-"));
+
+    try {
+      const result = runServerStartup(server, {
+        cwd,
+        env: { CODEX_PLUGIN_ROOT: pluginRoot },
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).not.toContain("bun: not found");
+      expect(result.stderr).not.toContain("could not find a package.json");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/weixin/start-codex.sh
+++ b/plugins/weixin/start-codex.sh
@@ -2,10 +2,32 @@
 # Start Codex App Server + Weixin bridge in one command.
 # Usage: ./start-codex.sh [ws://127.0.0.1:4500]
 
-set -e
+set -euo pipefail
+
+export PATH="$HOME/.bun/bin:$HOME/.volta/bin:$PATH"
 
 WS_URL="${1:-ws://127.0.0.1:4500}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APP_SERVER_PID=""
+
+cleanup() {
+  if [ -n "$APP_SERVER_PID" ]; then
+    kill "$APP_SERVER_PID" 2>/dev/null || true
+    wait "$APP_SERVER_PID" 2>/dev/null || true
+  fi
+}
+
+trap cleanup EXIT INT TERM
+
+if ! command -v codex >/dev/null 2>&1; then
+  echo "[weixin] codex command not found. Install Codex CLI first." >&2
+  exit 1
+fi
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "[weixin] bun command not found. Install Bun first: https://bun.sh" >&2
+  exit 1
+fi
 
 echo "[weixin] Starting Codex App Server at $WS_URL..."
 codex app-server --listen "$WS_URL" &
@@ -27,10 +49,7 @@ for i in $(seq 1 20); do
 done
 
 echo "[weixin] Installing dependencies..."
-bun install --no-summary --cwd "$SCRIPT_DIR"
+bun install --no-summary --frozen-lockfile --cwd "$SCRIPT_DIR"
 
 echo "[weixin] Starting Weixin bridge..."
 CODEX_WS_URL="$WS_URL" bun "$SCRIPT_DIR/server-codex.ts"
-
-# If bridge exits, stop app-server too
-kill $APP_SERVER_PID 2>/dev/null


### PR DESCRIPTION
## Summary
- Prevent the Codex Weixin MCP server from failing during `initialize` when Codex App launches it outside a login shell.
- Make the standalone Codex bridge script clean up its spawned app-server process and avoid lockfile churn during startup.

## Changes
- Add a plugin-relative `cwd` and explicit Bun PATH setup to `.codex-mcp.json`.
- Use `--frozen-lockfile` during startup dependency checks.
- Add regression coverage for sparse PATH and non-plugin working directory launches.
- Document the `connection closed: initialize response` troubleshooting path for Codex users.

## Testing
- [x] `bun test`
- [x] `bun run typecheck`
- [x] Verified installed plugin MCP handshake with a clean PATH environment